### PR TITLE
fix: typo in get_committer

### DIFF
--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -193,7 +193,7 @@ fn main() -> Result<()> {
                 let subcommand = matches.subcommand_matches(VERIFY).unwrap();
                 let message = subcommand.value_of("message").unwrap();
                 let author = CocoGitto::get()
-                    .map(|cogito| cogito.get_commiter().unwrap())
+                    .map(|cogito| cogito.get_committer().unwrap())
                     .ok();
 
                 match cocogitto::verify(author, message) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl CocoGitto {
         &COMMITS_METADATA
     }
 
-    pub fn get_commiter(&self) -> Result<String> {
+    pub fn get_committer(&self) -> Result<String> {
         self.repository.get_author()
     }
 


### PR DESCRIPTION
Noticed typo while fixing #34; fixed it here.