### PR TITLE
feat(cli): bump --pre flag to set the pre-release version

### DIFF
--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -146,6 +146,12 @@ fn main() -> Result<()> {
                 .long("minor")
                 .required_unless_one(&["version", "auto", "patch", "major"]),
         )
+        .arg(
+            Arg::with_name("pre")
+                .help("Set the pre-release version")
+                .long("pre")
+                .takes_value(true),
+        )
         .display_order(6);
 
     let init_subcommand = SubCommand::with_name(INIT)
@@ -186,8 +192,10 @@ fn main() -> Result<()> {
                     unreachable!()
                 };
 
+                let pre = subcommand.value_of("pre");
+
                 // TODO mode to cli
-                cocogitto.create_version(increment, WriterMode::Prepend)?
+                cocogitto.create_version(increment, WriterMode::Prepend, pre)?
             }
             VERIFY => {
                 let subcommand = matches.subcommand_matches(VERIFY).unwrap();

--- a/tests/cog_bump_test.rs
+++ b/tests/cog_bump_test.rs
@@ -112,3 +112,24 @@ fn patch_bump() -> Result<()> {
 
     Ok(std::env::set_current_dir(current_dir)?)
 }
+
+#[test]
+#[cfg(not(tarpaulin))]
+fn pre_release_bump() -> Result<()> {
+    let current_dir = std::env::current_dir()?;
+    let mut command = Command::cargo_bin("cog")?;
+    command.arg("bump").arg("--major").arg("--pre").arg("alpha");
+
+    let temp_dir = TempDir::default();
+    std::env::set_current_dir(&temp_dir)?;
+    helper::git_init(".")?;
+    helper::git_commit("chore: init")?;
+    helper::git_tag("1.0.0")?;
+    helper::git_commit("feat: feature")?;
+
+    command.assert().success();
+    assert!(temp_dir.join("CHANGELOG.md").exists());
+    helper::assert_tag("2.0.0-alpha")?;
+
+    Ok(std::env::set_current_dir(current_dir)?)
+}


### PR DESCRIPTION
Implementation of the feature discussed in #21 

Closes #21 