### PR TITLE
Fix incorrect behavior of 0.y.z autobumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,11 @@ Note that if your project already contains a changelog you can tell `cog` about 
 - - -
 ```
 
-You might also need to adjust `changelog_path` in `cog.toml`. 
+You might also need to adjust `changelog_path` in `cog.toml`.
+
+**Note:** `cog bump --auto` treats `0.y.z` versions specially,
+i.e. it will never do an auto bump to the `1.0.0` version, even if there are breaking changes.
+That way, you can keep adding features in the development stage and decide yourself, when your API is stable.
 
 ## Bump hooks
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -266,6 +266,44 @@ mod test {
     }
 
     #[test]
+    fn should_get_next_auto_version_breaking_changes_on_initial_dev_version() {
+        let feature = Commit {
+            oid: "1234".to_string(),
+            message: CommitMessage {
+                commit_type: CommitType::Feature,
+                scope: None,
+                body: None,
+                footer: None,
+                description: "feature".to_string(),
+                is_breaking_change: false,
+            },
+            author: "".to_string(),
+            date: Utc::now().naive_local(),
+        };
+
+        let breaking_change = Commit {
+            oid: "1234".to_string(),
+            message: CommitMessage {
+                commit_type: CommitType::Feature,
+                scope: None,
+                body: None,
+                footer: None,
+                description: "feature".to_string(),
+                is_breaking_change: true,
+            },
+            author: "".to_string(),
+            date: Utc::now().naive_local(),
+        };
+
+        let version = VersionIncrement::get_next_auto_version(
+            &Version::parse("0.1.0").unwrap(),
+            &[breaking_change, feature],
+        );
+
+        assert_eq!(version.unwrap(), Version::new(0, 2, 0))
+    }
+
+    #[test]
     fn should_get_next_auto_version_minor() {
         let patch = Commit {
             oid: "1234".to_string(),


### PR DESCRIPTION
Adds check to prevent auto bumping major when we're on a `0.y.z` version (initial development).

Closes #58