### PR TITLE
feat(bump): add --config flag to cog bump

### DIFF
--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -58,9 +58,10 @@ fn main() -> Result<()> {
                 };
 
                 let pre = subcommand.value_of("pre");
+                let hooks_config = subcommand.value_of("config");
 
                 // TODO mode to cli
-                cocogitto.create_version(increment, pre)?
+                cocogitto.create_version(increment, pre, hooks_config)?
             }
             VERIFY => {
                 let subcommand = matches.subcommand_matches(VERIFY).unwrap();
@@ -301,6 +302,13 @@ fn app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("pre")
                 .help("Set the pre-release version")
                 .long("pre")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("config")
+                .help("Specify path to hooks config file")
+                .short("c")
+                .long("config")
                 .takes_value(true),
         )
         .display_order(6);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,10 +50,10 @@ impl Default for Settings {
 
 impl Settings {
     // Fails only if config exists and is malformed
-    pub(crate) fn get(repository: &Repository) -> Result<Self> {
+    pub(crate) fn get(repository: &Repository, config_path: Option<&str>) -> Result<Self> {
         match repository.get_repo_dir() {
             Some(repo_path) => {
-                let settings_path = repo_path.join(CONFIG_PATH);
+                let settings_path = repo_path.join(config_path.unwrap_or(CONFIG_PATH));
                 if settings_path.exists() {
                     let mut s = Config::new();
                     s.merge(File::from(settings_path))?;


### PR DESCRIPTION
This PR adds the `--config` flag to `cog bump` closing #74.  

I couldn't figure any better way to pass the custom config file path to the `Settings` struct apart from passing it in the `Settings::get` function. 
But this change results in having to pass `None` whenever a custom config path is not needed. 
For example: `Settings::get(&repo, None).unwrap_or_default().authors` in `lib.rs:69`

Please let me know if this approach is acceptable, or if there could be a better approach to passing the custom `config_path` parameter to the `Settings` struct.

Also, I've tested this flag manually on sample git repos, and the hooks specified by the config file path run correctly.  Would we need to add any unit tests to test this flag?

Thanks.