### PR TITLE
Sort tags on semver format to discoved latest tag

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,4 +1,5 @@
 use super::status::Statuses;
+use semver::Version;
 use crate::error::ErrorKind;
 use crate::error::ErrorKind::Git;
 use crate::OidOf;
@@ -120,9 +121,19 @@ impl Repository {
 
     pub(crate) fn get_latest_tag(&self) -> Result<String> {
         let tag_names = self.0.tag_names(None)?;
+        let mut versions = Vec::new();
 
-        let tags = tag_names.iter().collect::<Vec<Option<&str>>>();
-        if let Some(Some(tag)) = tags.last() {
+        for tag in tag_names.iter().collect::<Vec<Option<&str>>>() {
+            if let Some(tag) = tag {
+                if let Ok(version) = Version::parse(tag) {
+                    versions.push(version);
+                }
+            }
+        }
+
+        versions.sort();
+
+        if let Some(tag) = versions.last() {
             Ok(tag.to_string())
         } else {
             Err(anyhow!("Unable to get any tag"))

--- a/tests/cog_bump_test.rs
+++ b/tests/cog_bump_test.rs
@@ -102,6 +102,32 @@ fn auto_bump_patch_from_latest_tag() -> Result<()> {
 
 #[test]
 #[cfg(not(tarpaulin))]
+fn auto_bump_respect_semver_sorting() -> Result<()> {
+    let current_dir = std::env::current_dir()?;
+    let mut command = Command::cargo_bin("cog")?;
+    command.arg("bump").arg("--auto");
+
+    let temp_dir = TempDir::default();
+    std::env::set_current_dir(&temp_dir)?;
+    helper::git_init(".")?;
+    helper::git_commit("chore: init")?;
+    helper::git_commit("feat(taef): feature")?;
+    helper::git_commit("fix: bug fix")?;
+    helper::git_tag("0.9.1")?;
+    helper::git_commit("feat(the_fix): feature")?;
+    helper::git_tag("0.10.0")?;
+    helper::git_commit("fix: fix 1")?;
+    helper::git_commit("fix: fix 2")?;
+
+    command.assert().success();
+    assert!(temp_dir.join("CHANGELOG.md").exists());
+    helper::assert_tag("0.10.1")?;
+
+    Ok(std::env::set_current_dir(current_dir)?)
+}
+
+#[test]
+#[cfg(not(tarpaulin))]
 fn minor_bump() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let mut command = Command::cargo_bin("cog")?;


### PR DESCRIPTION
This pull request is a potential fix for #83. It uses `semver::Version` to turn the tags into version objects that can be sorted based on semver convention.

There is also a test included that fails on the master version and succeeds with this fix.

Please bare in mind that Rust is not my daily language and the current state of the PR should be considered a starting point rather than the fix.

 I allowed edits by maintainers for this PR, please use it!