### PR TITLE
Clean up minor code details

### DIFF
--- a/src/bin/coco.rs
+++ b/src/bin/coco.rs
@@ -56,10 +56,10 @@ fn main() -> Result<()> {
 }
 
 fn app<'a, 'b>() -> App<'a, 'b> {
-    let keys = CocoGitto::get_commit_metadata()
+    let keys: Vec<&str> = CocoGitto::get_commit_metadata()
         .iter()
         .map(|(commit_type, _)| commit_type.as_ref())
-        .collect::<Vec<&str>>();
+        .collect();
 
     App::new("Coco")
         .settings(APP_SETTINGS)
@@ -69,7 +69,7 @@ fn app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("type")
                 .help("The type of the commit message")
-                .possible_values(keys.as_slice())
+                .possible_values(&keys)
                 .required(true),
         )
         .arg(

--- a/src/conventional/changelog.rs
+++ b/src/conventional/changelog.rs
@@ -66,9 +66,7 @@ impl Changelog {
             let meta = &COMMITS_METADATA[&commit_type];
 
             write!(&mut out, "\n### {}\n\n", meta.changelog_title).unwrap();
-            for description in commits {
-                out.push_str(&description);
-            }
+            out.extend(commits);
         }
 
         out
@@ -90,9 +88,7 @@ impl Changelog {
     }
 
     fn changelog_template() -> String {
-        let mut content = Changelog::default_header();
-        content.push_str(&Changelog::default_footer());
-        content
+        [Changelog::default_header(), Changelog::default_footer()].join("")
     }
 }
 

--- a/src/conventional/commit.rs
+++ b/src/conventional/commit.rs
@@ -280,14 +280,14 @@ impl Commit {
             "{}{} ({}) - {}\n\t{} {}\n\t{} {}\n\t{} {}\n",
             breaking_change,
             message_display,
-            &self.shorthand().bold(),
+            self.shorthand().bold(),
             elapsed,
             author_format,
-            &self.author,
+            self.author,
             type_format,
-            &self.message.commit_type,
+            self.message.commit_type,
             scope_format,
-            &self.message.scope.as_ref().unwrap_or(&"none".to_string()),
+            self.message.scope.as_deref().unwrap_or("none"),
         )
     }
 }
@@ -300,7 +300,7 @@ impl fmt::Display for Commit {
 
 impl AsRef<str> for CommitType {
     fn as_ref(&self) -> &str {
-        match &self {
+        match self {
             Feature => "feat",
             BugFix => "fix",
             Chore => "chore",

--- a/src/conventional/version.rs
+++ b/src/conventional/version.rs
@@ -62,7 +62,7 @@ impl VersionIncrement {
             .map(Result::unwrap)
             .collect();
 
-        VersionIncrement::get_next_auto_version(current_version, conventional_commits.as_slice())
+        VersionIncrement::get_next_auto_version(current_version, &conventional_commits)
     }
 
     fn get_next_auto_version(current_version: &Version, commits: &[Commit]) -> Result<Version> {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -55,7 +55,7 @@ impl Repository {
 
     pub(crate) fn add_all(&self) -> Result<()> {
         let mut index = self.0.index()?;
-        index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
+        index.add_all(["*"], IndexAddOption::DEFAULT, None)?;
         index.write().map_err(|err| anyhow!(err))
     }
 
@@ -107,10 +107,9 @@ impl Repository {
     pub(crate) fn get_head_commit(&self) -> Result<Git2Commit> {
         let head_ref = self.0.head();
         match head_ref {
-            Ok(head) => match head.peel_to_commit() {
-                Ok(head_commit) => Ok(head_commit),
-                Err(err) => Err(anyhow!("Could not peel head to commit {}", err)),
-            },
+            Ok(head) => head
+                .peel_to_commit()
+                .map_err(|err| anyhow!("Could not peel head to commit {}", err)),
             Err(err) => Err(anyhow!("Repo as not HEAD : {}", err)),
         }
     }

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -33,7 +33,7 @@ impl FromStr for Hook {
 
 impl fmt::Display for Hook {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let command = shell_words::join(self.0.iter());
+        let command = shell_words::join(&self.0);
         f.write_str(&command)
     }
 }
@@ -75,10 +75,7 @@ mod test {
     #[test]
     fn parse_valid_string() -> Result<()> {
         let hook = Hook::from_str("cargo bump {{version}}")?;
-        assert_eq!(
-            &hook.0,
-            &["cargo".to_string(), "bump".into(), "{{version}}".into()]
-        );
+        assert_eq!(&hook.0, &["cargo", "bump", "{{version}}"]);
         Ok(())
     }
 
@@ -87,10 +84,7 @@ mod test {
         let mut hook = Hook::from_str("cargo bump {{version}}")?;
         hook.insert_version("1.0.0").unwrap();
 
-        assert_eq!(
-            &hook.0,
-            &["cargo".to_string(), "bump".into(), "1.0.0".into()]
-        );
+        assert_eq!(&hook.0, &["cargo", "bump", "1.0.0"]);
         Ok(())
     }
 

--- a/src/hook/parser.rs
+++ b/src/hook/parser.rs
@@ -123,8 +123,7 @@ impl HookExpr {
             match token {
                 Token::Add => version = self.calculate_increment(version)?,
                 Token::AlphaNumeric(string) => {
-                    let mut output = version.to_string();
-                    output.push_str(&string);
+                    let output = [version.to_string(), string].join("");
                     return Ok(output);
                 }
                 _ => return Err(anyhow!("Unexpected token in hook expression : {:?}", token)),
@@ -193,7 +192,7 @@ mod tests {
         let (range, mut expr) = HookExpr::scan_hook_entry(entry).unwrap();
         expr.tokenize();
         assert_eq!(range, 5..22);
-        assert_eq!(expr.tokens, vec![Token::Version, Token::Add, Token::Minor])
+        assert_eq!(expr.tokens, [Token::Version, Token::Add, Token::Minor])
     }
 
     #[test]
@@ -206,7 +205,7 @@ mod tests {
         assert_eq!(range, 5..23);
         assert_eq!(
             expr.tokens,
-            vec![Token::Version, Token::Add, Token::Amount(2), Token::Major]
+            [Token::Version, Token::Add, Token::Amount(2), Token::Major]
         )
     }
 
@@ -220,7 +219,7 @@ mod tests {
         assert_eq!(range, 5..27);
         assert_eq!(
             expr.tokens,
-            vec![
+            [
                 Token::Version,
                 Token::Add,
                 Token::Amount(33),

--- a/src/log/filter.rs
+++ b/src/log/filter.rs
@@ -20,14 +20,14 @@ impl CommitFilters {
 
     pub(crate) fn filter_git2_commit(&self, commit: &Git2Commit) -> bool {
         // Author filters
-        let authors = self
+        let authors: Vec<&String> = self
             .0
             .iter()
             .filter_map(|filter| match filter {
                 CommitFilter::Author(author) => Some(author),
                 _ => None,
             })
-            .collect::<Vec<&String>>();
+            .collect();
 
         let filter_authors = if authors.is_empty() {
             true
@@ -42,14 +42,14 @@ impl CommitFilters {
 
     pub(crate) fn filters(&self, commit: &Commit) -> bool {
         // Commit type filters
-        let types = self
+        let types: Vec<&CommitType> = self
             .0
             .iter()
             .filter_map(|filter| match filter {
                 CommitFilter::Type(commit_type) => Some(commit_type),
                 _ => None,
             })
-            .collect::<Vec<&CommitType>>();
+            .collect();
 
         let filter_type = if types.is_empty() {
             true
@@ -60,21 +60,21 @@ impl CommitFilters {
         };
 
         // Scope filters
-        let scopes = self
+        let scopes: Vec<&String> = self
             .0
             .iter()
             .filter_map(|filter| match filter {
                 CommitFilter::Scope(scope) => Some(scope),
                 _ => None,
             })
-            .collect::<Vec<&String>>();
+            .collect();
 
         let filter_scopes = if scopes.is_empty() {
             true
         } else {
             scopes
                 .iter()
-                .any(|scope| Some(*scope) == commit.message.scope.as_ref())
+                .any(|&scope| Some(scope) == commit.message.scope.as_ref())
         };
 
         // Breaking changes filters

--- a/src/log/output.rs
+++ b/src/log/output.rs
@@ -119,7 +119,7 @@ impl OutputBuilder {
                 "must have a value, as ensured by checking existence of at least one default pager",
             );
 
-        let mut cmd = self.make_pager_command(&pager, &args[..]);
+        let mut cmd = self.make_pager_command(&pager, &args);
         let output = cmd
             .spawn()
             .map(Output::Pager)
@@ -194,10 +194,10 @@ impl OutputBuilder {
         if is_bat {
             self.file_name
                 .as_ref()
-                .map(|name| cmd.args(&["--file-name", name]));
+                .map(|name| cmd.args(["--file-name", name]));
         }
 
-        cmd.args(args.iter())
+        cmd.args(args)
             .env("LESSANSIENDCHARS", "mK")
             .stdin(Stdio::piped());
 

--- a/tests/coco_commit_test.rs
+++ b/tests/coco_commit_test.rs
@@ -82,7 +82,7 @@ fn empty_commit_err() -> Result<()> {
     let mut command = Command::cargo_bin("coco")?;
     let tmp = TempDir::new()?;
 
-    std::env::set_current_dir(&tmp.path().to_path_buf())?;
+    std::env::set_current_dir(tmp.path())?;
     helper::git_init(".")?;
 
     command


### PR DESCRIPTION
Highlights:

- Use `Deref` / `IntoIterator` when applicable
- Avoid some minor redundant allocation