### PR TITLE
fix: generate completions without opening a repository

### DIFF
--- a/src/bin/coco.rs
+++ b/src/bin/coco.rs
@@ -22,8 +22,6 @@ const SUBCOMMAND_SETTINGS: &[AppSettings] = &[
 const GENERATE_COMPLETIONS: &str = "generate-completions";
 
 fn main() -> Result<()> {
-    let cocogitto = CocoGitto::get()?;
-
     let matches = app().get_matches();
 
     if let Some(subcommand) = matches.subcommand_matches(GENERATE_COMPLETIONS) {
@@ -36,6 +34,8 @@ fn main() -> Result<()> {
         };
         app().gen_completions_to("coco", for_shell, &mut std::io::stdout());
     } else {
+        let cocogitto = CocoGitto::get()?;
+
         let commit_type = matches.value_of("type").unwrap().to_string();
         let message = matches.value_of("message").unwrap().to_string();
         let scope = matches.value_of("scope").map(|scope| scope.to_string());


### PR DESCRIPTION
Hello!

While generating shell completions for `coco`, I realized it first tries to open the repository in the current directory thus fails to generate completions when the current directory is not a git repository:

```
Error: could not find repository from '/build/cocogitto/src/cocogitto-3.0.0'; class=Repository (6); code=NotFound (-3)
```

These are two separate actions so I think it does not need to open the repository before generating shell completions.

This PR fixes this issue by moving the `CocoGitto::get()` call to the scope where it is needed.

