### PR TITLE
Switch cog arg parsing to structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "chrono",
- "clap",
  "colored",
  "config",
  "conventional_commit_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "serde_derive",
  "shell-words",
  "speculoos",
+ "structopt",
  "tempfile",
  "toml",
  "which",
@@ -326,6 +327,15 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -675,6 +685,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1007,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1130,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ shell-words = "^1"
 which = "^4"
 lazy_static = "^1"
 toml = "^0"
-clap = { version = "^2", optional = true }
 structopt = { version = "^0", optional = true }
 conventional_commit_parser = "^0"
 
@@ -41,7 +40,7 @@ speculoos = "0.7.0"
 
 [features]
 default = ["cli"]
-cli = ["clap", "structopt"]
+cli = ["structopt"]
 
 [lib]
 name = "cocogitto"
@@ -50,12 +49,12 @@ path = "src/lib.rs"
 [[bin]]
 name = "cog"
 path = "src/bin/cog.rs"
-required-features = ["clap", "structopt"]
+required-features = ["structopt"]
 
 [[bin]]
 name = "coco"
 path = "src/bin/coco.rs"
-required-features = ["clap"]
+required-features = ["structopt"]
 
 [[test]]
 name = "all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ which = "^4"
 lazy_static = "^1"
 toml = "^0"
 clap = { version = "^2", optional = true }
+structopt = { version = "^0", optional = true }
 conventional_commit_parser = "^0"
 
 [dev-dependencies]
@@ -40,7 +41,7 @@ speculoos = "0.7.0"
 
 [features]
 default = ["cli"]
-cli = [ "clap"]
+cli = ["clap", "structopt"]
 
 [lib]
 name = "cocogitto"
@@ -49,7 +50,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "cog"
 path = "src/bin/cog.rs"
-required-features = ["clap"]
+required-features = ["clap", "structopt"]
 
 [[bin]]
 name = "coco"

--- a/src/bin/coco.rs
+++ b/src/bin/coco.rs
@@ -1,103 +1,71 @@
 #![cfg(not(tarpaulin_include))]
 use anyhow::Result;
-use clap::{App, AppSettings, Arg, Shell, SubCommand};
+use structopt::clap::{AppSettings, Shell};
+use structopt::StructOpt;
+
 use cocogitto::CocoGitto;
 use cocogitto::COMMITS_METADATA;
 
 const APP_SETTINGS: &[AppSettings] = &[
-    AppSettings::ArgsNegateSubcommands,
-    AppSettings::SubcommandsNegateReqs,
     AppSettings::UnifiedHelpMessage,
     AppSettings::ColoredHelp,
-    AppSettings::VersionlessSubcommands,
     AppSettings::DeriveDisplayOrder,
 ];
 
-const SUBCOMMAND_SETTINGS: &[AppSettings] = &[
-    AppSettings::UnifiedHelpMessage,
-    AppSettings::ColoredHelp,
-    AppSettings::VersionlessSubcommands,
-    AppSettings::DeriveDisplayOrder,
-];
+fn metadata_as_commit_types() -> Vec<&'static str> {
+    COMMITS_METADATA
+        .iter()
+        .map(|(commit_type, _)| commit_type.as_ref())
+        .collect()
+}
 
-const GENERATE_COMPLETIONS: &str = "generate-completions";
+/// A command line tool to create conventional commits
+#[derive(StructOpt)]
+#[structopt(name = "Coco", author = "Paul D. <paul.delafosse@protonmail.com>", settings = APP_SETTINGS)]
+struct Cli {
+    /// Conventional commit type
+    #[structopt(name = "type", possible_values = &metadata_as_commit_types(), default_value_if("completion", None, "chore"))]
+    typ: String,
+
+    /// Commit description
+    #[structopt(default_value_if("completion", None, ""))]
+    message: String,
+
+    /// Conventional commit scope
+    scope: Option<String>,
+
+    /// Commit message body
+    body: Option<String>,
+
+    /// Commit message footer
+    footer: Option<String>,
+
+    /// Create a BREAKING CHANGE commit
+    #[structopt(short = "B", long)]
+    breaking_change: bool,
+
+    /// Generate shell completions
+    #[structopt(long, conflicts_with = "type")]
+    completion: Option<Shell>,
+}
 
 fn main() -> Result<()> {
-    let matches = app().get_matches();
+    let cli = Cli::from_args();
 
-    if let Some(subcommand) = matches.subcommand_matches(GENERATE_COMPLETIONS) {
-        let for_shell = match subcommand.value_of("type").unwrap() {
-            "bash" => Shell::Bash,
-            "elvish" => Shell::Elvish,
-            "fish" => Shell::Fish,
-            "zsh" => Shell::Zsh,
-            _ => unreachable!(),
-        };
-        app().gen_completions_to("coco", for_shell, &mut std::io::stdout());
+    if let Some(shell) = cli.completion {
+        Cli::clap().gen_completions_to("coco", shell, &mut std::io::stdout());
     } else {
         let cocogitto = CocoGitto::get()?;
 
-        let commit_type = matches.value_of("type").unwrap().to_string();
-        let message = matches.value_of("message").unwrap().to_string();
-        let scope = matches.value_of("scope").map(|scope| scope.to_string());
-        let body = matches.value_of("body").map(|body| body.to_string());
-        let footers = matches.value_of("footer").map(|footer| footer.to_string());
-        let breaking_change = matches.is_present("breaking-change");
-
         cocogitto.conventional_commit(
-            &commit_type,
-            scope,
-            message,
-            body,
-            footers,
-            breaking_change,
+            &cli.typ,
+            cli.scope,
+            cli.message,
+            cli.body,
+            cli.footer,
+            cli.breaking_change,
         )?;
     }
 
     Ok(())
-}
-
-fn app<'a, 'b>() -> App<'a, 'b> {
-    let keys: Vec<&str> = COMMITS_METADATA
-        .iter()
-        .map(|(commit_type, _)| commit_type.as_ref())
-        .collect();
-
-    App::new("Coco")
-        .settings(APP_SETTINGS)
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Paul D. <paul.delafosse@protonmail.com>")
-        .about("A command line tool to create conventional commits")
-        .arg(
-            Arg::with_name("type")
-                .help("The type of the commit message")
-                .possible_values(&keys)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("message")
-                .help("The type of the commit message")
-                .required(true),
-        )
-        .arg(Arg::with_name("scope").help("The scope of the commit message"))
-        .arg(Arg::with_name("body").help("The body of the commit message"))
-        .arg(Arg::with_name("footer").help("The footer of the commit message"))
-        .arg(
-            Arg::with_name("breaking-change")
-                .help("BREAKING CHANGE commit")
-                .short("B")
-                .long("breaking-change"),
-        )
-        .subcommand(
-            SubCommand::with_name(GENERATE_COMPLETIONS)
-                .settings(SUBCOMMAND_SETTINGS)
-                .about("Generate shell completions")
-                .arg(
-                    Arg::with_name("type")
-                        .possible_values(&["bash", "elvish", "fish", "zsh"])
-                        .required(true)
-                        .takes_value(true)
-                        .help("Type of completions to generate"),
-                ),
-        )
 }

--- a/src/bin/cog.rs
+++ b/src/bin/cog.rs
@@ -1,6 +1,9 @@
 #![cfg(not(tarpaulin_include))]
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
-use clap::{App, AppSettings, Arg, Shell, SubCommand};
+use structopt::clap::{AppSettings, Shell};
+use structopt::StructOpt;
 
 use cocogitto::conventional::commit;
 use cocogitto::conventional::version::VersionIncrement;
@@ -20,364 +23,257 @@ const APP_SETTINGS: &[AppSettings] = &[
 const SUBCOMMAND_SETTINGS: &[AppSettings] = &[
     AppSettings::UnifiedHelpMessage,
     AppSettings::ColoredHelp,
-    AppSettings::VersionlessSubcommands,
     AppSettings::DeriveDisplayOrder,
 ];
 
-const BUMP: &str = "bump";
-const CHECK: &str = "check";
-const EDIT: &str = "edit";
-const LOG: &str = "log";
-const VERIFY: &str = "verify";
-const CHANGELOG: &str = "changelog";
-const INIT: &str = "init";
-const INSTALL_GIT_HOOK: &str = "install-hook";
-const GENERATE_COMPLETIONS: &str = "generate-completions";
-
-fn main() -> Result<()> {
-    let matches = app().get_matches();
-
-    if let Some(subcommand) = matches.subcommand_name() {
-        match subcommand {
-            BUMP => {
-                let mut cocogitto = CocoGitto::get()?;
-                let subcommand = matches.subcommand_matches(BUMP).unwrap();
-
-                let increment = if let Some(version) = subcommand.value_of("version") {
-                    VersionIncrement::Manual(version.to_string())
-                } else if subcommand.is_present("auto") {
-                    VersionIncrement::Auto
-                } else if subcommand.is_present("major") {
-                    VersionIncrement::Major
-                } else if subcommand.is_present("patch") {
-                    VersionIncrement::Patch
-                } else if subcommand.is_present("minor") {
-                    VersionIncrement::Minor
-                } else {
-                    unreachable!()
-                };
-
-                let pre = subcommand.value_of("pre");
-                let hooks_profile = subcommand.value_of("hook-profile");
-
-                // TODO mode to cli
-                cocogitto.create_version(increment, pre, hooks_profile)?
-            }
-            VERIFY => {
-                let subcommand = matches.subcommand_matches(VERIFY).unwrap();
-                let message = subcommand.value_of("message").unwrap();
-                let author = CocoGitto::get()
-                    .map(|cogito| cogito.get_committer().unwrap())
-                    .ok();
-
-                commit::verify(author, message)?;
-            }
-
-            CHECK => {
-                let cocogitto = CocoGitto::get()?;
-                let subcommand = matches.subcommand_matches(CHECK).unwrap();
-                let from_tag = subcommand.is_present("from-latest-tag");
-                cocogitto.check(from_tag)?;
-            }
-            EDIT => {
-                let cocogitto = CocoGitto::get()?;
-                cocogitto.check_and_edit()?;
-            }
-            LOG => {
-                let cocogitto = CocoGitto::get()?;
-
-                let repo_tag_name = cocogitto.get_repo_tag_name();
-                let repo_tag_name = repo_tag_name.as_deref().unwrap_or("cog log");
-
-                let mut output = Output::builder()
-                    .with_pager_from_env("PAGER")
-                    .with_file_name(repo_tag_name)
-                    .build()?;
-
-                let subcommand = matches.subcommand_matches(LOG).unwrap();
-
-                let mut filters = vec![];
-                if let Some(commit_types) = subcommand.values_of("type") {
-                    filters.extend(
-                        commit_types.map(|commit_type| CommitFilter::Type(commit_type.into())),
-                    );
-                }
-
-                if let Some(scopes) = subcommand.values_of("scope") {
-                    filters.extend(scopes.map(|scope| CommitFilter::Scope(scope.to_string())));
-                }
-
-                if let Some(authors) = subcommand.values_of("author") {
-                    filters.extend(authors.map(|author| CommitFilter::Author(author.to_string())));
-                }
-
-                if subcommand.is_present("breaking-change") {
-                    filters.push(CommitFilter::BreakingChange);
-                }
-
-                if subcommand.is_present("no-error") {
-                    filters.push(CommitFilter::NoError);
-                }
-
-                let filters = CommitFilters(filters);
-
-                let content = cocogitto.get_log(filters)?;
-                output
-                    .handle()?
-                    .write_all(content.as_bytes())
-                    .context("failed to write log into the pager")?;
-            }
-            CHANGELOG => {
-                let cocogitto = CocoGitto::get()?;
-                let subcommand = matches.subcommand_matches(CHANGELOG).unwrap();
-                let at = subcommand.value_of("at");
-                let result = match at {
-                    Some(at) => cocogitto.get_colored_changelog_at_tag(at)?,
-                    None => {
-                        let from = subcommand.value_of("from");
-                        let to = subcommand.value_of("to");
-                        cocogitto.get_colored_changelog(from, to)?
-                    }
-                };
-                println!("{}", result);
-            }
-
-            INIT => {
-                let subcommand = matches.subcommand_matches(INIT).unwrap();
-                let init_path = subcommand.value_of("path").unwrap(); // safe unwrap via clap default value
-                cocogitto::init(init_path)?;
-            }
-
-            INSTALL_GIT_HOOK => {
-                let subcommand = matches.subcommand_matches(INSTALL_GIT_HOOK).unwrap();
-                let hook_type = subcommand.value_of("hook-type").unwrap(); // safe unwrap via clap default value
-                let cocogitto = CocoGitto::get()?;
-                match hook_type {
-                    "pre-commit" => cocogitto.install_hook(HookKind::PrepareCommit)?,
-                    "pre-push" => cocogitto.install_hook(HookKind::PrePush)?,
-                    "all" => cocogitto.install_hook(HookKind::All)?,
-                    _ => unreachable!(),
-                }
-            }
-
-            GENERATE_COMPLETIONS => {
-                let generate_subcommand = matches.subcommand_matches(GENERATE_COMPLETIONS).unwrap();
-                let for_shell = match generate_subcommand.value_of("type").unwrap() {
-                    "bash" => Shell::Bash,
-                    "elvish" => Shell::Elvish,
-                    "fish" => Shell::Fish,
-                    "zsh" => Shell::Zsh,
-                    _ => unreachable!(),
-                };
-                app().gen_completions_to("cog", for_shell, &mut std::io::stdout());
-            }
-
-            _ => unreachable!(),
-        }
-    }
-    Ok(())
-}
-
-fn app<'a, 'b>() -> App<'a, 'b> {
-    let hook_profiles: Vec<&str> = HOOK_PROFILES
+fn hook_profiles() -> Vec<&'static str> {
+    HOOK_PROFILES
         .iter()
         .map(|profile| profile.as_ref())
-        .collect();
+        .collect()
+}
 
-    let check_command = SubCommand::with_name(CHECK)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Verify all commit message against the conventional commit specification")
-        .arg(
-            Arg::with_name("from-latest-tag")
-                .help("Check commit history, starting from the latest tag to HEAD")
-                .short("l")
-                .takes_value(false)
-                .long("from-latest-tag"),
-        )
-        .display_order(1);
+/// A command line tool for the conventional commits and semver specifications
+#[derive(StructOpt)]
+#[structopt(name = "Cog", author = "Paul D. <paul.delafosse@protonmail.com>", settings = APP_SETTINGS)]
+enum Cli {
+    /// Verify all commit messages against the conventional commit specification
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Check {
+        /// Check commit history, starting from the latest tag to HEAD
+        #[structopt(short = "l", long)]
+        from_latest_tag: bool,
+    },
 
-    let edit_command = SubCommand::with_name(EDIT)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Interactively rename invalid commit message")
-        .display_order(2);
+    /// Interactively rename invalid commit messages
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Edit,
 
-    let log_command = SubCommand::with_name(LOG)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Like git log but for conventional commits")
-        .arg(
-            Arg::with_name("breaking-change")
-                .help("filter BREAKING CHANGE commit")
-                .short("B")
-                .long("breaking-change"),
-        )
-        .arg(
-            Arg::with_name("type")
-                .help("filter on commit type")
-                .short("t")
-                .takes_value(true)
-                .multiple(true)
-                .long("type"),
-        )
-        .arg(
-            Arg::with_name("author")
-                .help("filter on commit author")
-                .short("a")
-                .takes_value(true)
-                .multiple(true)
-                .long("author"),
-        )
-        .arg(
-            Arg::with_name("scope")
-                .help("filter on commit scope")
-                .short("s")
-                .takes_value(true)
-                .multiple(true)
-                .long("scope"),
-        )
-        .arg(
-            Arg::with_name("no-error")
-                .help("omit error on the commit log")
-                .short("e")
-                .long("no-error"),
-        )
-        .display_order(3);
+    /// Like git log but for conventional commits
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Log {
+        /// filter BREAKING CHANGE commits
+        #[structopt(short = "B", long)]
+        breaking_change: bool,
 
-    let verify_command = SubCommand::with_name(VERIFY)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Verify a single commit message")
-        .arg(Arg::with_name("message").help("The commit message"))
-        .display_order(4);
+        /// filter on commit type
+        #[structopt(short, long = "type", value_name = "type")]
+        typ: Option<Vec<String>>,
 
-    let changelog_command = SubCommand::with_name(CHANGELOG)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Display a changelog for a given commit oid range")
-        .arg(
-            Arg::with_name("from")
-                .help("Generate the changelog from this commit or tag ref, default latest tag")
-                .short("f")
-                .long("from")
-                .conflicts_with("at")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("to")
-                .help("Generate the changelog to this commit or tag ref, default HEAD")
-                .short("t")
-                .long("to")
-                .conflicts_with("at")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("at")
-                .help("Generate the changelog for a specific git tag")
-                .short("at")
-                .long("at")
-                .takes_value(true)
-                .conflicts_with_all(&["from", "to"]),
-        )
-        .display_order(5);
+        /// filter on commit author
+        #[structopt(short, long)]
+        author: Option<Vec<String>>,
 
-    let bump_command = SubCommand::with_name(BUMP)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Commit changelog from latest tag to HEAD and create a new tag")
-        .arg(
-            Arg::with_name("version")
-                .help("Manually set the next version")
-                .short("v")
-                .takes_value(true)
-                .long("version")
-                .required_unless_one(&["auto", "major", "patch", "minor"]),
-        )
-        .arg(
-            Arg::with_name("auto")
-                .help("Atomatically suggest the next version")
-                .short("a")
-                .long("auto")
-                .required_unless_one(&["version", "major", "patch", "minor"]),
-        )
-        .arg(
-            Arg::with_name("major")
-                .help("Increment the major version")
-                .short("M")
-                .long("major")
-                .required_unless_one(&["version", "auto", "patch", "minor"]),
-        )
-        .arg(
-            Arg::with_name("patch")
-                .help("Increment the patch version")
-                .short("p")
-                .long("patch")
-                .required_unless_one(&["version", "auto", "major", "minor"]),
-        )
-        .arg(
-            Arg::with_name("minor")
-                .help("Increment the minor version")
-                .short("m")
-                .long("minor")
-                .required_unless_one(&["version", "auto", "patch", "major"]),
-        )
-        .arg(
-            Arg::with_name("pre")
-                .help("Set the pre-release version")
-                .long("pre")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("hook-profile")
-                .help("Specify the bump profile hooks to run")
-                .short("hp")
-                .long("hook-profile")
-                .possible_values(&hook_profiles)
-                .takes_value(true),
-        )
-        .display_order(6);
+        /// filter on commit scope
+        #[structopt(short, long)]
+        scope: Option<Vec<String>>,
 
-    let init_subcommand = SubCommand::with_name(INIT)
-        .settings(SUBCOMMAND_SETTINGS)
-        .arg(
-            Arg::with_name("path")
-                .help("path to init, default")
-                .default_value("."),
-        )
-        .about("Install cog config files");
+        /// omit error on the commit log
+        #[structopt(short = "e", long)]
+        no_error: bool,
+    },
 
-    let install_git_hook = SubCommand::with_name(INSTALL_GIT_HOOK)
-        .settings(SUBCOMMAND_SETTINGS)
-        .about("Add git hooks to the repository")
-        .arg(
-            Arg::with_name("hook-type")
-                .help("Type of hook to install")
-                .takes_value(true)
-                .required(true)
-                .possible_values(&["pre-commit", "pre-push", "all"]),
-        )
-        .display_order(7);
+    /// Verify a single commit message
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Verify {
+        /// The commit message
+        message: String,
+    },
 
-    App::new("Cog")
-        .settings(APP_SETTINGS)
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Paul D. <paul.delafosse@protonmail.com>")
-        .about("A command line tool for the conventional commits and semver specifications")
-        .subcommands([
-            verify_command,
-            init_subcommand,
-            check_command,
-            edit_command,
-            log_command,
-            changelog_command,
-            bump_command,
-            install_git_hook,
-        ])
-        .subcommand(
-            SubCommand::with_name(GENERATE_COMPLETIONS)
-                .settings(SUBCOMMAND_SETTINGS)
-                .about("Generate shell completions")
-                .arg(
-                    Arg::with_name("type")
-                        .possible_values(&["bash", "elvish", "fish", "zsh"])
-                        .required(true)
-                        .takes_value(true)
-                        .help("Type of completions to generate"),
-                ),
-        )
+    /// Display a changelog for the given commit oid range
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Changelog {
+        /// Generate the changelog from this commit or tag ref, default latest tag
+        #[structopt(short, long, conflicts_with = "at")]
+        from: Option<String>,
+
+        /// Generate the changelog to this commit or tag ref, default HEAD
+        #[structopt(short, long, conflicts_with = "at")]
+        to: Option<String>,
+
+        /// Generate the changelog for a specific git tag
+        #[structopt(short, long)]
+        at: Option<String>,
+    },
+
+    /// Commit changelog from latest tag to HEAD and create new tag
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Bump {
+        /// Manually set the next version
+        #[structopt(short, long, required_unless_one = &["auto", "major", "minor", "patch"])]
+        version: Option<String>,
+
+        /// Automatically suggest the next version
+        #[structopt(short, long, required_unless_one = &["version", "major", "minor", "patch"])]
+        auto: bool,
+
+        /// Increment the major version
+        #[structopt(short = "M", long, required_unless_one = &["version", "auto", "minor", "patch"])]
+        major: bool,
+
+        /// Increment the minor version
+        #[structopt(short, long, required_unless_one = &["version", "auto", "major", "patch"])]
+        minor: bool,
+
+        /// Increment the patch version
+        #[structopt(short, long, required_unless_one = &["version", "auto", "major", "minor"])]
+        patch: bool,
+
+        /// Set the pre-release version
+        #[structopt(long)]
+        pre: Option<String>,
+
+        /// Specify the bump profile hooks to run
+        #[structopt(short, long, possible_values = &hook_profiles())]
+        hook_profile: Option<String>,
+    },
+
+    /// Install cog config files
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    Init {
+        /// path to init
+        #[structopt(default_value = ".")]
+        path: PathBuf,
+    },
+
+    /// Add git hooks to the repository
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    InstallHook {
+        /// Type of hook to install
+        #[structopt(possible_values = &["pre-commit", "pre-push", "all"])]
+        hook_type: String,
+    },
+
+    /// Generate shell completions
+    #[structopt(no_version, settings = SUBCOMMAND_SETTINGS)]
+    GenerateCompletions {
+        /// Type of completions to generate
+        #[structopt(name = "type", possible_values = &["bash", "elvish", "fish", "zsh"])]
+        shell: Shell,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::from_args();
+
+    match cli {
+        Cli::Bump {
+            version,
+            auto,
+            major,
+            minor,
+            patch,
+            pre,
+            hook_profile,
+        } => {
+            let mut cocogitto = CocoGitto::get()?;
+
+            let increment = if let Some(version) = version {
+                VersionIncrement::Manual(version)
+            } else if auto {
+                VersionIncrement::Auto
+            } else if major {
+                VersionIncrement::Major
+            } else if minor {
+                VersionIncrement::Minor
+            } else if patch {
+                VersionIncrement::Patch
+            } else {
+                unreachable!()
+            };
+
+            // TODO mode to cli
+            cocogitto.create_version(increment, pre.as_deref(), hook_profile.as_deref())?
+        }
+        Cli::Verify { message } => {
+            let author = CocoGitto::get()
+                .map(|cogito| cogito.get_committer().unwrap())
+                .ok();
+
+            commit::verify(author, &message)?;
+        }
+        Cli::Check { from_latest_tag } => {
+            let cocogitto = CocoGitto::get()?;
+            cocogitto.check(from_latest_tag)?;
+        }
+        Cli::Edit => {
+            let cocogitto = CocoGitto::get()?;
+            cocogitto.check_and_edit()?;
+        }
+        Cli::Log {
+            breaking_change,
+            typ,
+            author,
+            scope,
+            no_error,
+        } => {
+            let cocogitto = CocoGitto::get()?;
+
+            let repo_tag_name = cocogitto.get_repo_tag_name();
+            let repo_tag_name = repo_tag_name.as_deref().unwrap_or("cog log");
+
+            let mut output = Output::builder()
+                .with_pager_from_env("PAGER")
+                .with_file_name(repo_tag_name)
+                .build()?;
+
+            let mut filters = vec![];
+            if let Some(commit_types) = typ {
+                filters.extend(
+                    commit_types
+                        .iter()
+                        .map(|commit_type| CommitFilter::Type(commit_type.as_str().into())),
+                );
+            }
+
+            if let Some(scopes) = scope {
+                filters.extend(scopes.into_iter().map(CommitFilter::Scope));
+            }
+
+            if let Some(authors) = author {
+                filters.extend(authors.into_iter().map(CommitFilter::Author));
+            }
+
+            if breaking_change {
+                filters.push(CommitFilter::BreakingChange);
+            }
+
+            if no_error {
+                filters.push(CommitFilter::NoError);
+            }
+
+            let filters = CommitFilters(filters);
+
+            let content = cocogitto.get_log(filters)?;
+            output
+                .handle()?
+                .write_all(content.as_bytes())
+                .context("failed to write log into the pager")?;
+        }
+        Cli::Changelog { from, to, at } => {
+            let cocogitto = CocoGitto::get()?;
+            let result = match at {
+                Some(at) => cocogitto.get_colored_changelog_at_tag(&at)?,
+                None => cocogitto.get_colored_changelog(from.as_deref(), to.as_deref())?,
+            };
+            println!("{}", result);
+        }
+        Cli::Init { path } => {
+            cocogitto::init(&path)?;
+        }
+        Cli::InstallHook { hook_type } => {
+            let cocogitto = CocoGitto::get()?;
+            match hook_type.as_str() {
+                "pre-commit" => cocogitto.install_hook(HookKind::PrepareCommit)?,
+                "pre-push" => cocogitto.install_hook(HookKind::PrePush)?,
+                "all" => cocogitto.install_hook(HookKind::All)?,
+                _ => unreachable!(),
+            }
+        }
+        Cli::GenerateCompletions { shell } => {
+            Cli::clap().gen_completions_to("cog", shell, &mut std::io::stdout());
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Replaces raw clap with structopt in `cog` to avoid boilerplate code (manual checks and clap method calls).

I also attempted to do the same in `coco` but structopt doesn't like the combination of required positional args and subcommands.