### PR TITLE
Add edit flag for coco

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "colored",
  "config",
  "conventional_commit_parser",
+ "edit",
  "git2",
  "indoc",
  "itertools",
@@ -242,6 +243,16 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "edit"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdd6936f8bd9782e28932eef853bfcd8548992ce5748bb3e7e88bad613d0ee0"
+dependencies = [
+ "tempfile",
+ "which",
+]
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "^1"
 colored = "^2"
 chrono = "^0"
 config = { version = "^0", default-features = false, features = ["toml"] }
+edit = "^0"
 itertools = "^0"
 serde_derive = "^1"
 serde = "^1"

--- a/src/bin/coco.rs
+++ b/src/bin/coco.rs
@@ -1,5 +1,9 @@
 #![cfg(not(tarpaulin_include))]
-use anyhow::Result;
+use std::fmt::Write;
+
+use anyhow::{bail, Result};
+use conventional_commit_parser::commit::Footer;
+use itertools::Itertools;
 use structopt::clap::{AppSettings, Shell};
 use structopt::StructOpt;
 
@@ -11,6 +15,43 @@ const APP_SETTINGS: &[AppSettings] = &[
     AppSettings::ColoredHelp,
     AppSettings::DeriveDisplayOrder,
 ];
+
+const EDIT_TEMPLATE: &str = "# Enter the commit message for your changes.
+# Lines starting with # will be ignored, and empty body/footer are allowed.
+# Once you are done, save the changes and exit the editor.
+# Remove all non-comment lines to abort.
+#
+";
+
+fn prepare_header(typ: &str, message: &str, scope: Option<&str>) -> String {
+    let mut header = typ.to_string();
+
+    if let Some(scope) = scope {
+        write!(&mut header, "({})", scope).unwrap();
+    }
+
+    write!(&mut header, ": {}", message).unwrap();
+
+    header
+}
+
+fn prepare_edit_template(typ: &str, message: &str, scope: Option<&str>, breaking: bool) -> String {
+    let mut template: String = EDIT_TEMPLATE.into();
+    let header = prepare_header(typ, message, scope);
+
+    if breaking {
+        template.push_str("# WARNING: This will be marked as a breaking change!\n");
+    }
+
+    write!(
+        &mut template,
+        "{}\n\n# Message body\n\n\n# Message footer\n# For example, foo: bar\n\n\n",
+        header
+    )
+    .unwrap();
+
+    template
+}
 
 fn metadata_as_commit_types() -> Vec<&'static str> {
     COMMITS_METADATA
@@ -34,15 +75,13 @@ struct Cli {
     /// Conventional commit scope
     scope: Option<String>,
 
-    /// Commit message body
-    body: Option<String>,
-
-    /// Commit message footer
-    footer: Option<String>,
-
     /// Create a BREAKING CHANGE commit
     #[structopt(short = "B", long)]
     breaking_change: bool,
+
+    /// Open commit message in an editor
+    #[structopt(short, long)]
+    edit: bool,
 
     /// Generate shell completions
     #[structopt(long, conflicts_with = "type")]
@@ -57,14 +96,47 @@ fn main() -> Result<()> {
     } else {
         let cocogitto = CocoGitto::get()?;
 
-        cocogitto.conventional_commit(
-            &cli.typ,
-            cli.scope,
-            cli.message,
-            cli.body,
-            cli.footer,
-            cli.breaking_change,
-        )?;
+        let (body, footer, breaking) = if cli.edit {
+            let template = prepare_edit_template(
+                &cli.typ,
+                &cli.message,
+                cli.scope.as_deref(),
+                cli.breaking_change,
+            );
+
+            let edited = edit::edit(&template)?;
+
+            if edited.lines().all(|line| {
+                let trimmed = line.trim_start();
+                trimmed.is_empty() || trimmed.starts_with('#')
+            }) {
+                bail!("Aborted commit message edit");
+            }
+
+            let content = edited
+                .lines()
+                .filter(|&line| !line.trim_start().starts_with('#'))
+                .join("\n");
+
+            let mut cc = conventional_commit_parser::parse(content.trim())?;
+
+            let footer = if !cc.footers.is_empty() {
+                let Footer { token, content } = cc.footers.swap_remove(0);
+                Some(format!("{}: {}", token, content.trim()))
+            } else {
+                None
+            };
+
+            (
+                cc.body.map(|s| s.trim().to_string()),
+                footer,
+                cc.is_breaking_change || cli.breaking_change,
+            )
+        } else {
+            (None, None, cli.breaking_change)
+        };
+
+        cocogitto.conventional_commit(&cli.typ, cli.scope, cli.message, body, footer, breaking)?;
     }
 
     Ok(())


### PR DESCRIPTION
Implements #103

Default look:
![obraz](https://user-images.githubusercontent.com/5671049/135096017-84995ee0-8b13-4ff7-a53d-42d1bdcfb807.png)

With the `-B` flag:
![obraz](https://user-images.githubusercontent.com/5671049/135096128-39508d18-ccd2-4651-89d4-57c9560200b6.png)
